### PR TITLE
Ignore known_hosts file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
         php-apc && \
     rm -rf /var/lib/apt/lists/*
 
+RUN sed -i "s/#   StrictHostKeyChecking ask\n   StrictHostKeyChecking no/" /etc/ssh/ssh_config
 RUN sed -i "s/variables_order.*/variables_order = \"EGPCS\"/g" /etc/php5/apache2/php.ini
 RUN sed -i "s/variables_order.*/variables_order = \"EGPCS\"/g" /etc/php5/cli/php.ini
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer


### PR DESCRIPTION
Fix so deployment ignore known_hosts since we already supply login hostkey file.